### PR TITLE
Change owner from go-spectest to nao1215

### DIFF
--- a/.github/workflows/multi_ver_unittest.yml
+++ b/.github/workflows/multi_ver_unittest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.18", "1.20"]
+        go-version: ["1.18", "1.22"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Vuluncheck](https://github.com/nao1215/diff/actions/workflows/govulncheck.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/govulncheck.yml)
 [![reviewdog](https://github.com/nao1215/diff/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/reviewdog.yml)
 [![Gosec](https://github.com/nao1215/diff/actions/workflows/security.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/security.yml)
-![Coverage](https://github.com/go-spectest/octocovs-central-repo/blob/main//badges/nao1215/diff/coverage.svg?raw=true)
+![Coverage](https://github.com/nao1215/octocovs-central-repo/blob/main//badges/nao1215/diff/coverage.svg?raw=true)
 ## nao1215/diff package
 
 This repository is forked from [pmezard/go-difflib](https://github.com/pmezard/go-difflib) by [Stein Fletcher](https://github.com/steinfletcher). He was maintaining difflib within the apitest package.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-[![LinuxUnitTest](https://github.com/go-spectest/diff/actions/workflows/linux_test.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/linux_test.yml)
-[![MacUnitTest](https://github.com/go-spectest/diff/actions/workflows/mac_test.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/mac_test.yml)
-[![WindowsUnitTest](https://github.com/go-spectest/diff/actions/workflows/windows_test.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/windows_test.yml)
-[![Vuluncheck](https://github.com/go-spectest/diff/actions/workflows/govulncheck.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/govulncheck.yml)
-[![reviewdog](https://github.com/go-spectest/diff/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/reviewdog.yml)
-[![Gosec](https://github.com/go-spectest/diff/actions/workflows/security.yml/badge.svg)](https://github.com/go-spectest/diff/actions/workflows/security.yml)
-![Coverage](https://github.com/go-spectest/octocovs-central-repo/blob/main//badges/go-spectest/diff/coverage.svg?raw=true)
-## go-spectest/diff package
+[![LinuxUnitTest](https://github.com/nao1215/diff/actions/workflows/linux_test.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/linux_test.yml)
+[![MacUnitTest](https://github.com/nao1215/diff/actions/workflows/mac_test.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/mac_test.yml)
+[![WindowsUnitTest](https://github.com/nao1215/diff/actions/workflows/windows_test.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/windows_test.yml)
+[![Vuluncheck](https://github.com/nao1215/diff/actions/workflows/govulncheck.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/govulncheck.yml)
+[![reviewdog](https://github.com/nao1215/diff/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/reviewdog.yml)
+[![Gosec](https://github.com/nao1215/diff/actions/workflows/security.yml/badge.svg)](https://github.com/nao1215/diff/actions/workflows/security.yml)
+![Coverage](https://github.com/go-spectest/octocovs-central-repo/blob/main//badges/nao1215/diff/coverage.svg?raw=true)
+## nao1215/diff package
 
 This repository is forked from [pmezard/go-difflib](https://github.com/pmezard/go-difflib) by [Stein Fletcher](https://github.com/steinfletcher). He was maintaining difflib within the apitest package.
   
-When I forked the apitest package as the spectest package, I moved the go-spectest/diff package to a separate repository. I do not have the intention to extend the functionality of go-spectest/diff, but I will maintain it while maintaining the spectest package.
+When I forked the apitest package as the spectest package, I moved the nao1215/diff package to a separate repository. I do not have the intention to extend the functionality of nao1215/diff, but I will maintain it while maintaining the spectest package.
 
 The difference from the original version is that the standard output ("+++", "---" output) is colored even in the Windows environment. In other words, there is no longer any functional difference from Linux or Mac even on Windows.
 
-## What is go-spectest/diff package ?
-The go-spectest/diff is a partial port of python 3 difflib package. Its main goal was to make unified and context diff available in pure Go, mostly for testing purposes.
+## What is nao1215/diff package ?
+The nao1215/diff is a partial port of python 3 difflib package. Its main goal was to make unified and context diff available in pure Go, mostly for testing purposes.
 
 The following class and functions (and related tests) have be ported:
 
@@ -25,7 +25,7 @@ The following class and functions (and related tests) have be ported:
 ## Installation
 
 ```bash
-$ go get github.com/go-spectest/diff
+$ go get github.com/nao1215/diff
 ```
 
 ## Supported OS

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-spectest/diff
+module github.com/nao1215/diff
 
 go 1.18
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Go version used in our workflows from 1.20 to 1.22 for improved performance and compatibility.
- **Documentation**
	- Updated the repository name in documentation to `nao1215/diff`, including badges, package references, and mentions. Enhanced support for color output on Windows has been noted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->